### PR TITLE
fix:修复textSize的measure方法测量文本宽高的问题

### DIFF
--- a/harmony/text_size/src/main/ets/RNTextSizeTurboModule.ts
+++ b/harmony/text_size/src/main/ets/RNTextSizeTurboModule.ts
@@ -25,20 +25,23 @@
 import { TurboModule } from "@rnoh/react-native-openharmony/ts";
 import font from '@ohos.font'
 import measure, { MeasureOptions } from '@ohos.measure'
-import { config } from './config';
+import { config } from './Config';
 import display from '@ohos.display';
 
 export class RNTextSizeTurboModule extends TurboModule {
   measure(options: TSMeasureParams): Promise<TSMeasureResult> {
     return new Promise<TSMeasureResult>((resolve, reject) => {
       try {
-        let text = options.text;
-        let width = options.width;
-        let lineCount = options.lineInfoForLine
+        let lineCount = options.lineInfoForLine || 0;
         let measureText: MeasureOptions = {
-          textContent: text,
+          textContent: options.text,
+          fontFamily: options.fontFamily,
+          fontSize: options.fontSize,
+          fontWeight: options.fontWeight,
+          letterSpacing: options.letterSpacing,
         }
         let textSize = config(measureText);
+        let width: number = textSize.width as number;
         let height: number = textSize.height as number;
         let result: TSMeasureResult = {
           width: width,
@@ -61,6 +64,10 @@ export class RNTextSizeTurboModule extends TurboModule {
         fontHeight = text.reduce<number[]>((prev, value) => {
           let measureText: MeasureOptions = {
             textContent: value,
+            fontFamily: options.fontFamily,
+            fontSize: options.fontSize,
+            fontWeight: options.fontWeight,
+            letterSpacing: options.letterSpacing,
           }
           let textSize = config(measureText);
           let height: number = textSize.height as number;


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- close #5 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

